### PR TITLE
Don't remove linux-libc-dev when removing old kernels

### DIFF
--- a/ubuntu-post-install-script.sh
+++ b/ubuntu-post-install-script.sh
@@ -478,7 +478,7 @@ if [ $INPUT -eq 1 ]; then
 elif [ $INPUT -eq 2 ]; then
     echo 'Removing old Kernel(s)...'
     echo 'Requires root privileges:'
-    sudo dpkg -l 'linux-*' | sed '/^ii/!d;/'"$(uname -r | sed "s/\(.*\)-\([^0-9]\+\)/\1/")"'/d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d' | xargs sudo apt-get -y purge
+    sudo dpkg -l 'linux-*' | sed '/^ii/!d;/'"$(uname -r | sed "s/\(.*\)-\([^0-9]\+\)/\1/")"'/d;s/^[^ ]* [^ ]* \([^ ]*\).*/\1/;/[0-9]/!d' | grep -v linux-libc-dev | xargs sudo apt-get -y purge
     echo 'Done.'
     cleanup
 # Remove Orphaned Packages


### PR DESCRIPTION
I ran the old kernel clean function and it tried to remove a whole bunch of dev stuff due to linux-libc-dev being purged. This commit excludes it if you would like it in.
