### PR TITLE
fix($bug): space password failed in the elevate_privilege

### DIFF
--- a/functions/password
+++ b/functions/password
@@ -16,7 +16,7 @@ function elevate_privilege() {
 			PASSWORD=$(whiptail --passwordbox "\nRequires admin privileges to continue. \n\nPlease enter your password:\n" 12 48 --title "Password Required" 3>&1 1>&2 2>&3)
 			exitstatus=$?
 			if [ $exitstatus = 0 ]; then
-				$SUDOCMD -S <<< $PASSWORD $@
+				$SUDOCMD -S <<< "$PASSWORD" $@
 				exitstatus=$?
 				if [ $exitstatus = 1 ]; then
 					display_error "Incorrect password. Aborting..."


### PR DESCRIPTION
when the password contains a few spaces in the front, the
elevate_privilege fail to get the password.
Change $PASSWORD to "$PASSWORD" to fix it.